### PR TITLE
Use clock_gettime with CLOCK_MONOTONIC instead of gettimeofday

### DIFF
--- a/pipe_lat.c
+++ b/pipe_lat.c
@@ -1,4 +1,4 @@
-/* 
+/*
     Measure latency of IPC using unix domain sockets
 
 
@@ -73,12 +73,12 @@ int main(int argc, char *argv[])
 
   if (!fork()) {  /* child */
     for (i = 0; i < count; i++) {
-      
+
       if (read(ifds[0], buf, size) != size) {
         perror("read");
         return 1;
       }
-      
+
       if (write(ofds[1], buf, size) != size) {
         perror("write");
         return 1;
@@ -110,6 +110,6 @@ int main(int argc, char *argv[])
     printf("average latency: %lli us\n", delta / (count * 2));
 
   }
-  
+
   return 0;
 }

--- a/pipe_thr.c
+++ b/pipe_thr.c
@@ -32,6 +32,11 @@
 #include <sys/socket.h>
 #include <time.h>
 #include <stdint.h>
+#include <unistd.h>
+
+#if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
+#define HAS_CLOCK_GETTIME_MONOTONIC
+#endif
 
 
 int main(int argc, char *argv[])
@@ -41,7 +46,11 @@ int main(int argc, char *argv[])
   int size;
   char *buf;
   int64_t count, i, delta;
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+  struct timespec start, stop;
+#else
   struct timeval start, stop;
+#endif
 
   if (argc != 3) {
     printf ("usage: pipe_thr <message-size> <message-count>\n");
@@ -77,7 +86,17 @@ int main(int argc, char *argv[])
   } else {
     /* parent */
 
-    gettimeofday(&start, NULL);
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+    if (clock_gettime(CLOCK_MONOTONIC, &start) == -1) {
+      perror("clock_gettime");
+      return 1;
+    }
+#else
+    if (gettimeofday(&start, NULL) == -1) {
+      perror("gettimeofday");
+      return 1;
+    }
+#endif
 
     for (i = 0; i < count; i++) {
       if (write(fds[1], buf, size) != size) {
@@ -86,13 +105,28 @@ int main(int argc, char *argv[])
       }
     }
 
-    gettimeofday(&stop, NULL);
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+    if (clock_gettime(CLOCK_MONOTONIC, &stop) == -1) {
+      perror("clock_gettime");
+      return 1;
+    }
 
-    delta = ((stop.tv_sec - start.tv_sec) * (int64_t) 1e6 +
-	     stop.tv_usec - start.tv_usec);
+    delta = ((stop.tv_sec - start.tv_sec) * 1000000 +
+             (stop.tv_nsec - start.tv_nsec) / 1000);
 
-    printf("average throughput: %lli msg/s\n", (count * (int64_t) 1e6) / delta);
-    printf("average throughput: %lli Mb/s\n", (((count * (int64_t) 1e6) / delta) * size * 8) / (int64_t) 1e6);
+#else
+    if (gettimeofday(&stop, NULL) == -1) {
+      perror("gettimeofday");
+      return 1;
+    }
+
+    delta = (stop.tv_sec - start.tv_sec) * 1000000 +
+            (stop.tv_usec - start.tv_usec);
+
+#endif
+
+    printf("average throughput: %lli msg/s\n", (count * 1000000) / delta);
+    printf("average throughput: %lli Mb/s\n", (((count * 1000000) / delta) * size * 8) / 1000000);
   }
 
   return 0;

--- a/pipe_thr.c
+++ b/pipe_thr.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
 
   if (argc != 3) {
     printf ("usage: pipe_thr <message-size> <message-count>\n");
-    exit(1);
+    return 1;
   }
 
   size = atoi(argv[1]);
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
   buf = malloc(size);
   if (buf == NULL) {
     perror("malloc");
-    exit(1);
+    return 1;
   }
 
   printf("message size: %i octets\n", size);
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
 
   if (pipe(fds) == -1) {
     perror("pipe");
-    exit(1);
+    return 1;
   }
 
   if (!fork()) {
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
     for (i = 0; i < count; i++) {
       if (read(fds[0], buf, size) != size) {
         perror("read");
-        exit(1);
+        return 1;
       }
     }
   } else {
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     for (i = 0; i < count; i++) {
       if (write(fds[1], buf, size) != size) {
         perror("write");
-        exit(1);
+        return 1;
       }
     }
 

--- a/pipe_thr.c
+++ b/pipe_thr.c
@@ -1,4 +1,4 @@
-/* 
+/*
     Measure throughput of IPC using pipes
 
 
@@ -65,16 +65,16 @@ int main(int argc, char *argv[])
     exit(1);
   }
 
-  if (!fork()) {  
+  if (!fork()) {
     /* child */
 
-    for (i = 0; i < count; i++) {      
+    for (i = 0; i < count; i++) {
       if (read(fds[0], buf, size) != size) {
         perror("read");
         exit(1);
       }
     }
-  } else { 
+  } else {
     /* parent */
 
     gettimeofday(&start, NULL);
@@ -94,6 +94,6 @@ int main(int argc, char *argv[])
     printf("average throughput: %lli msg/s\n", (count * (int64_t) 1e6) / delta);
     printf("average throughput: %lli Mb/s\n", (((count * (int64_t) 1e6) / delta) * size * 8) / (int64_t) 1e6);
   }
-  
+
   return 0;
 }

--- a/shm.c
+++ b/shm.c
@@ -39,7 +39,7 @@ int main(void)
      */
     if ((shmid = shmget(key, 100, IPC_CREAT | 0666)) < 0) {
       perror("shmget");
-      exit(1);
+      return 1;
     }
 
     /*
@@ -47,7 +47,7 @@ int main(void)
      */
     if ((shm = shmat(shmid, NULL, 0)) == (struct timespec*) -1) {
       perror("shmat");
-      exit(1);
+      return 1;
     }
 
     while (1) {
@@ -63,7 +63,7 @@ int main(void)
      */
     if ((shmid = shmget(key, 100, 0666)) < 0) {
       perror("shmget");
-      exit(1);
+      return 1;
     }
 
     /*
@@ -71,7 +71,7 @@ int main(void)
      */
     if ((shm = shmat(shmid, NULL, 0)) == (struct timespec *) -1) {
       perror("shmat");
-      exit(1);
+      return 1;
     }
 
     while (1) {

--- a/shm.c
+++ b/shm.c
@@ -10,9 +10,6 @@
 
 int main(void)
 {
-  int pfds[2];
-  
-  char c;
   int shmid;
   key_t key;
   struct timespec *shm;

--- a/shm.c
+++ b/shm.c
@@ -17,8 +17,6 @@ int main(void)
   key_t key;
   struct timespec *shm;
 
-
-
   struct timespec start, stop;
 
   int64_t delta;
@@ -33,7 +31,7 @@ int main(void)
    * "5678".
    */
   key = 5678;
-  
+
   if (!fork()) {
 
     /*
@@ -83,20 +81,20 @@ int main(void)
       start = *shm;
       delta = ((stop.tv_sec - start.tv_sec) * (int64_t) 1000000000 +
                stop.tv_nsec - start.tv_nsec);
-      
+
       if (delta > max)
         max = delta;
       else if (delta < min)
         min = delta;
-      
+
       sum += delta;
       count++;
-      
+
       if (!(count % 100)) {
         printf("%lli %lli %lli\n", max, min, sum / count);
       }
     }
   }
-  
+
   return 0;
 }

--- a/tcp_lat.c
+++ b/tcp_lat.c
@@ -84,30 +84,30 @@ int main(int argc, char *argv[])
 
     if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
       perror("socket");
-      exit(1);
+      return 1;
     }
 
     if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
       perror("setsockopt");
-      exit(1);
-    } 
-    
+      return 1;
+    }
+
     if (bind(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
       perror("bind");
-      exit(1);
+      return 1;
     }
 
     if (listen(sockfd, 1) == -1) {
       perror("listen");
-      exit(1);
-    } 
-    
+      return 1;
+    }
+
     addr_size = sizeof their_addr;
 
     if ((new_fd = accept(sockfd, (struct sockaddr *)&their_addr, &addr_size)) == -1) {
       perror("accept");
-      exit(1);
-    } 
+      return 1;
+    }
 
     for (i = 0; i < count; i++) {
 
@@ -131,12 +131,12 @@ int main(int argc, char *argv[])
 
     if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
       perror("socket");
-      exit(1);
+      return 1;
     }
 
     if (connect(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
       perror("connect");
-      exit(1);
+      return 1;
     }
 
     gettimeofday(&start, NULL);

--- a/tcp_lat.c
+++ b/tcp_lat.c
@@ -1,4 +1,4 @@
-/* 
+/*
     Measure latency of IPC using tcp sockets
 
 
@@ -96,30 +96,30 @@ int main(int argc, char *argv[])
       perror("bind");
       exit(1);
     }
-    
+
     if (listen(sockfd, 1) == -1) {
       perror("listen");
       exit(1);
     } 
     
     addr_size = sizeof their_addr;
-    
+
     if ((new_fd = accept(sockfd, (struct sockaddr *)&their_addr, &addr_size)) == -1) {
       perror("accept");
       exit(1);
     } 
 
     for (i = 0; i < count; i++) {
-      
+
       for (sofar = 0; sofar < size; ) {
-	len = read(new_fd, buf, size - sofar);
-	if (len == -1) {
-	  perror("read");
-	  return 1;
-	}
-	sofar += len;
+        len = read(new_fd, buf, size - sofar);
+        if (len == -1) {
+          perror("read");
+          return 1;
+        }
+        sofar += len;
       }
-            
+
       if (write(new_fd, buf, size) != size) {
         perror("write");
         return 1;
@@ -128,12 +128,12 @@ int main(int argc, char *argv[])
   } else { /* parent */
 
     sleep(1);
-    
+
     if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
       perror("socket");
       exit(1);
     }
-    
+
     if (connect(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
       perror("connect");
       exit(1);
@@ -149,12 +149,12 @@ int main(int argc, char *argv[])
       }
 
       for (sofar = 0; sofar < size; ) {
-	len = read(sockfd, buf, size - sofar);
-	if (len == -1) {
-	  perror("read");
-	  return 1;
-	}
-	sofar += len;
+        len = read(sockfd, buf, size - sofar);
+        if (len == -1) {
+          perror("read");
+          return 1;
+        }
+        sofar += len;
       }
       
     }
@@ -167,6 +167,6 @@ int main(int argc, char *argv[])
     printf("average latency: %lli us\n", delta / (count * 2));
 
   }
-  
+
   return 0;
 }

--- a/tcp_lat.c
+++ b/tcp_lat.c
@@ -34,6 +34,11 @@
 #include <time.h>
 #include <stdint.h>
 #include <netdb.h>
+#include <unistd.h>
+
+#if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
+#define HAS_CLOCK_GETTIME_MONOTONIC
+#endif
 
 
 int main(int argc, char *argv[])
@@ -41,7 +46,11 @@ int main(int argc, char *argv[])
   int size;
   char *buf;
   int64_t count, i, delta;
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+  struct timespec start, stop;
+#else
   struct timeval start, stop;
+#endif
 
   ssize_t len;
   size_t sofar;
@@ -139,7 +148,17 @@ int main(int argc, char *argv[])
       return 1;
     }
 
-    gettimeofday(&start, NULL);
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+    if (clock_gettime(CLOCK_MONOTONIC, &start) == -1) {
+      perror("clock_gettime");
+      return 1;
+    }
+#else
+    if (gettimeofday(&start, NULL) == -1) {
+      perror("gettimeofday");
+      return 1;
+    }
+#endif
 
     for (i = 0; i < count; i++) {
 
@@ -156,14 +175,29 @@ int main(int argc, char *argv[])
         }
         sofar += len;
       }
-      
+
     }
 
-    gettimeofday(&stop, NULL);
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+    if (clock_gettime(CLOCK_MONOTONIC, &stop) == -1) {
+      perror("clock_gettime");
+      return 1;
+    }
 
-    delta = ((stop.tv_sec - start.tv_sec) * (int64_t) 1e6 +
-	     stop.tv_usec - start.tv_usec);
-    
+    delta = ((stop.tv_sec - start.tv_sec) * 1000000 +
+             (stop.tv_nsec - start.tv_nsec) / 1000);
+
+#else
+    if (gettimeofday(&stop, NULL) == -1) {
+      perror("gettimeofday");
+      return 1;
+    }
+
+    delta = (stop.tv_sec - start.tv_sec) * 1000000 +
+            (stop.tv_usec - start.tv_usec);
+
+#endif
+
     printf("average latency: %lli us\n", delta / (count * 2));
 
   }

--- a/tcp_local_lat.c
+++ b/tcp_local_lat.c
@@ -40,8 +40,7 @@ int main(int argc, char *argv[])
 {
   int size;
   char *buf;
-  int64_t count, i, delta;
-  struct timeval start, stop;
+  int64_t count, i;
 
   ssize_t len;
   size_t sofar;

--- a/tcp_local_lat.c
+++ b/tcp_local_lat.c
@@ -82,30 +82,30 @@ int main(int argc, char *argv[])
 
   if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
     perror("socket");
-    exit(1);
+    return 1;
   }
 
   if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
     perror("setsockopt");
-    exit(1);
-  } 
-    
+    return 1;
+  }
+
   if (bind(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
     perror("bind");
-    exit(1);
+    return 1;
   }
 
   if (listen(sockfd, 1) == -1) {
     perror("listen");
-    exit(1);
-  } 
-    
+    return 1;
+  }
+
   addr_size = sizeof their_addr;
 
   if ((new_fd = accept(sockfd, (struct sockaddr *)&their_addr, &addr_size)) == -1) {
     perror("accept");
-    exit(1);
-  } 
+    return 1;
+  }
 
   for (i = 0; i < count; i++) {
 

--- a/tcp_local_lat.c
+++ b/tcp_local_lat.c
@@ -1,4 +1,4 @@
-/* 
+/*
     Measure latency of IPC using tcp sockets
 
 
@@ -94,35 +94,35 @@ int main(int argc, char *argv[])
     perror("bind");
     exit(1);
   }
-    
+
   if (listen(sockfd, 1) == -1) {
     perror("listen");
     exit(1);
   } 
     
   addr_size = sizeof their_addr;
-    
+
   if ((new_fd = accept(sockfd, (struct sockaddr *)&their_addr, &addr_size)) == -1) {
     perror("accept");
     exit(1);
   } 
 
   for (i = 0; i < count; i++) {
-      
+
     for (sofar = 0; sofar < size; ) {
       len = read(new_fd, buf, size - sofar);
       if (len == -1) {
-	perror("read");
-	return 1;
+        perror("read");
+        return 1;
       }
       sofar += len;
     }
-            
+
     if (write(new_fd, buf, size) != size) {
       perror("write");
       return 1;
     }
   }
-  
+
   return 0;
 }

--- a/tcp_remote_lat.c
+++ b/tcp_remote_lat.c
@@ -1,4 +1,4 @@
-/* 
+/*
     Measure latency of IPC using tcp sockets
 
 
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
     fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(ret));
     return 1;
   }
-    
+
   if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
     perror("socket");
     exit(1);
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
     fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(ret));
     return 1;
   }
-    
+
   if (connect(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
     perror("connect");
     exit(1);
@@ -112,8 +112,8 @@ int main(int argc, char *argv[])
     for (sofar = 0; sofar < size; ) {
       len = read(sockfd, buf, size - sofar);
       if (len == -1) {
-	perror("read");
-	return 1;
+        perror("read");
+        return 1;
       }
       sofar += len;
     }
@@ -126,6 +126,6 @@ int main(int argc, char *argv[])
 	   stop.tv_usec - start.tv_usec);
     
   printf("average latency: %lli us\n", delta / (count * 2));
-  
+
   return 0;
 }

--- a/tcp_remote_lat.c
+++ b/tcp_remote_lat.c
@@ -82,12 +82,12 @@ int main(int argc, char *argv[])
 
   if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
     perror("socket");
-    exit(1);
+    return 1;
   }
 
   if (bind(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
     perror("bind");
-    exit(1);
+    return 1;
   }
 
   if ((ret = getaddrinfo(argv[2], argv[3], &hints, &res)) != 0) {
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
 
   if (connect(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
     perror("connect");
-    exit(1);
+    return 1;
   }
 
   gettimeofday(&start);

--- a/tcp_remote_lat.c
+++ b/tcp_remote_lat.c
@@ -46,13 +46,10 @@ int main(int argc, char *argv[])
   ssize_t len;
   size_t sofar;
 
-  int yes = 1;
   int ret;
-  struct sockaddr_storage their_addr;
-  socklen_t addr_size;
   struct addrinfo hints;
   struct addrinfo *res;
-  int sockfd, new_fd;
+  int sockfd;
 
   if (argc != 6) {
     printf ("usage: tcp_lat <bind-to> <host> <port> <message-size> <roundtrip-count>\n");

--- a/tcp_thr.c
+++ b/tcp_thr.c
@@ -1,4 +1,4 @@
-/* 
+/*
     Measure throughput of IPC using tcp sockets
 
 
@@ -98,14 +98,14 @@ int main(int argc, char *argv[])
       perror("bind");
       exit(1);
     }
-    
+
     if (listen(sockfd, 1) == -1) {
       perror("listen");
       exit(1);
     } 
     
     addr_size = sizeof their_addr;
-    
+
     if ((new_fd = accept(sockfd, (struct sockaddr *)&their_addr, &addr_size)) == -1) {
       perror("accept");
       exit(1);
@@ -119,21 +119,21 @@ int main(int argc, char *argv[])
       }
       sofar += len;
     }
-  } else { 
+  } else {
     /* parent */
 
     sleep(1);
-    
+
     if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
       perror("socket");
       exit(1);
     }
-    
+
     if (connect(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
       perror("connect");
       exit(1);
     }
-    
+
     if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(int)) == -1) {
       perror("setsockopt");
       exit(1);
@@ -156,6 +156,6 @@ int main(int argc, char *argv[])
     printf("average throughput: %lli msg/s\n", (count * (int64_t) 1e6) / delta);
     printf("average throughput: %lli Mb/s\n", (((count * (int64_t) 1e6) / delta) * size * 8) / (int64_t) 1e6);
   }
-  
+
   return 0;
 }

--- a/tcp_thr.c
+++ b/tcp_thr.c
@@ -35,6 +35,12 @@
 #include <stdint.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
+#include <unistd.h>
+
+#if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
+#define HAS_CLOCK_GETTIME_MONOTONIC
+#endif
+
 
 
 int main(int argc, char *argv[])
@@ -42,7 +48,11 @@ int main(int argc, char *argv[])
   int size;
   char *buf;
   int64_t count, i, delta;
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+  struct timespec start, stop;
+#else
   struct timeval start, stop;
+#endif
 
   ssize_t len;
   size_t sofar;
@@ -138,8 +148,18 @@ int main(int argc, char *argv[])
       perror("setsockopt");
       return 1;
     }
-    
-    gettimeofday(&start, NULL);
+
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+    if (clock_gettime(CLOCK_MONOTONIC, &start) == -1) {
+      perror("clock_gettime");
+      return 1;
+    }
+#else
+    if (gettimeofday(&start, NULL) == -1) {
+      perror("gettimeofday");
+      return 1;
+    }
+#endif
 
     for (i = 0; i < count; i++) {
       if (write(sockfd, buf, size) != size) {
@@ -148,13 +168,28 @@ int main(int argc, char *argv[])
       }
     }
 
-    gettimeofday(&stop, NULL);
-    
-    delta = ((stop.tv_sec - start.tv_sec) * (int64_t) 1e6 +
-	     stop.tv_usec - start.tv_usec);
-    
-    printf("average throughput: %lli msg/s\n", (count * (int64_t) 1e6) / delta);
-    printf("average throughput: %lli Mb/s\n", (((count * (int64_t) 1e6) / delta) * size * 8) / (int64_t) 1e6);
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+    if (clock_gettime(CLOCK_MONOTONIC, &stop) == -1) {
+      perror("clock_gettime");
+      return 1;
+    }
+
+    delta = ((stop.tv_sec - start.tv_sec) * 1000000 +
+             (stop.tv_nsec - start.tv_nsec) / 1000);
+
+#else
+    if (gettimeofday(&stop, NULL) == -1) {
+      perror("gettimeofday");
+      return 1;
+    }
+
+    delta = (stop.tv_sec - start.tv_sec) * 1000000 +
+            (stop.tv_usec - start.tv_usec);
+
+#endif
+
+    printf("average throughput: %lli msg/s\n", (count * 1000000) / delta);
+    printf("average throughput: %lli Mb/s\n", (((count * 1000000) / delta) * size * 8) / 1000000);
   }
 
   return 0;

--- a/tcp_thr.c
+++ b/tcp_thr.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
   buf = malloc(size);
   if (buf == NULL) {
     perror("malloc");
-    exit(1);
+    return 1;
   }
 
   memset(&hints, 0, sizeof hints);
@@ -86,36 +86,36 @@ int main(int argc, char *argv[])
 
     if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
       perror("socket");
-      exit(1);
+      return 1;
     }
 
     if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
       perror("setsockopt");
-      exit(1);
-    } 
-    
+      return 1;
+    }
+
     if (bind(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
       perror("bind");
-      exit(1);
+      return 1;
     }
 
     if (listen(sockfd, 1) == -1) {
       perror("listen");
-      exit(1);
-    } 
-    
+      return 1;
+    }
+
     addr_size = sizeof their_addr;
 
     if ((new_fd = accept(sockfd, (struct sockaddr *)&their_addr, &addr_size)) == -1) {
       perror("accept");
-      exit(1);
-    } 
+      return 1;
+    }
 
     for (sofar = 0; sofar < (count * size);) {
       len = read(new_fd, buf, size);
       if (len == -1) {
 	perror("read");
-        exit(1);
+        return 1;
       }
       sofar += len;
     }
@@ -126,17 +126,17 @@ int main(int argc, char *argv[])
 
     if ((sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol)) == -1) {
       perror("socket");
-      exit(1);
+      return 1;
     }
 
     if (connect(sockfd, res->ai_addr, res->ai_addrlen) == -1) {
       perror("connect");
-      exit(1);
+      return 1;
     }
 
     if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(int)) == -1) {
       perror("setsockopt");
-      exit(1);
+      return 1;
     }
     
     gettimeofday(&start, NULL);
@@ -144,8 +144,8 @@ int main(int argc, char *argv[])
     for (i = 0; i < count; i++) {
       if (write(sockfd, buf, size) != size) {
         perror("write");
-        exit(1);
-      }      
+        return 1;
+      }
     }
 
     gettimeofday(&stop, NULL);

--- a/unix_lat.c
+++ b/unix_lat.c
@@ -32,6 +32,11 @@
 #include <sys/socket.h>
 #include <time.h>
 #include <stdint.h>
+#include <unistd.h>
+
+#if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0) && defined(_POSIX_MONOTONIC_CLOCK)
+#define HAS_CLOCK_GETTIME_MONOTONIC
+#endif
 
 
 int main(int argc, char *argv[])
@@ -40,7 +45,11 @@ int main(int argc, char *argv[])
   int size;
   char *buf;
   int64_t count, i, delta;
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+  struct timespec start, stop;
+#else
   struct timeval start, stop;
+#endif
 
   if (argc != 3) {
     printf ("usage: unix_lat <message-size> <roundtrip-count>\n");
@@ -79,7 +88,17 @@ int main(int argc, char *argv[])
     }
   } else { /* parent */
 
-    gettimeofday(&start, NULL);
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+    if (clock_gettime(CLOCK_MONOTONIC, &start) == -1) {
+      perror("clock_gettime");
+      return 1;
+    }
+#else
+    if (gettimeofday(&start, NULL) == -1) {
+      perror("gettimeofday");
+      return 1;
+    }
+#endif
 
     for (i = 0; i < count; i++) {
 
@@ -92,14 +111,29 @@ int main(int argc, char *argv[])
         perror("read");
         return 1;
       }
-      
+
     }
 
-    gettimeofday(&stop, NULL);
+#ifdef HAS_CLOCK_GETTIME_MONOTONIC
+    if (clock_gettime(CLOCK_MONOTONIC, &stop) == -1) {
+      perror("clock_gettime");
+      return 1;
+    }
 
-    delta = ((stop.tv_sec - start.tv_sec) * (int64_t) 1e6 +
-	     stop.tv_usec - start.tv_usec);
-    
+    delta = ((stop.tv_sec - start.tv_sec) * 1000000 +
+             (stop.tv_nsec - start.tv_nsec) / 1000);
+
+#else
+    if (gettimeofday(&stop, NULL) == -1) {
+      perror("gettimeofday");
+      return 1;
+    }
+
+    delta = (stop.tv_sec - start.tv_sec) * 1000000 +
+            (stop.tv_usec - start.tv_usec);
+
+#endif
+
     printf("average latency: %lli us\n", delta / (count * 2));
 
   }

--- a/unix_lat.c
+++ b/unix_lat.c
@@ -1,4 +1,4 @@
-/* 
+/*
     Measure latency of IPC using unix domain sockets
 
 
@@ -66,12 +66,12 @@ int main(int argc, char *argv[])
 
   if (!fork()) {  /* child */
     for (i = 0; i < count; i++) {
-      
+
       if (read(sv[1], buf, size) != size) {
         perror("read");
         return 1;
       }
-      
+
       if (write(sv[1], buf, size) != size) {
         perror("write");
         return 1;
@@ -103,6 +103,6 @@ int main(int argc, char *argv[])
     printf("average latency: %lli us\n", delta / (count * 2));
 
   }
-  
+
   return 0;
 }

--- a/unix_lat.c
+++ b/unix_lat.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
 
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1) {
     perror("socketpair");
-    exit(1);
+    return 1;
   }
 
   if (!fork()) {  /* child */

--- a/unix_thr.c
+++ b/unix_thr.c
@@ -1,4 +1,4 @@
-/* 
+/*
     Measure throughput of IPC using unix domain sockets.
 
 
@@ -63,17 +63,17 @@ int main(int argc, char *argv[])
     perror("socketpair");
     exit(1);
   }
-  
-  if (!fork()) {  
+
+  if (!fork()) {
     /* child */
 
-    for (i = 0; i < count; i++) {      
+    for (i = 0; i < count; i++) {
       if (read(fds[1], buf, size) != size) {
         perror("read");
 	exit(1);
       }
     }
-  } else { 
+  } else {
     /* parent */
   
     gettimeofday(&start, NULL);
@@ -93,6 +93,6 @@ int main(int argc, char *argv[])
     printf("average throughput: %lli msg/s\n", (count * (int64_t) 1e6) / delta);
     printf("average throughput: %lli Mb/s\n", (((count * (int64_t) 1e6) / delta) * size * 8) / (int64_t) 1e6);
   }
-  
+
   return 0;
 }

--- a/unix_thr.c
+++ b/unix_thr.c
@@ -44,16 +44,16 @@ int main(int argc, char *argv[])
 
   if (argc != 3) {
     printf ("usage: unix_thr <message-size> <message-count>\n");
-    exit(1);
+    return 1;
   }
-  
+
   size = atoi(argv[1]);
   count = atol(argv[2]);
 
   buf = malloc(size);
   if (buf == NULL) {
     perror("malloc");
-    exit(1);
+    return 1;
   }
 
   printf("message size: %i octets\n", size);
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
 
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == -1) {
     perror("socketpair");
-    exit(1);
+    return 1;
   }
 
   if (!fork()) {
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     for (i = 0; i < count; i++) {
       if (read(fds[1], buf, size) != size) {
         perror("read");
-	exit(1);
+        return 1;
       }
     }
   } else {
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
     for (i = 0; i < count; i++) {
       if (write(fds[0], buf, size) != size) {
         perror("write");
-        exit(1);
+        return 1;
       }
     }
 


### PR DESCRIPTION
Benefits:
* Best resolution available to measure short time intervals
* Prevents bug if for example ntpd ajusts the clock during the test (see: https://blog.habets.se/2010/09/gettimeofday-should-never-be-used-to-measure-time)