### PR TITLE
Fix format specification

### DIFF
--- a/src/pipe_lat.c
+++ b/src/pipe_lat.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
   }
 
   printf("message size: %i octets\n", size);
-  printf("roundtrip count: %li\n", count);
+  printf("roundtrip count: %lli\n", count);
 
   if (pipe(ofds) == -1) {
     perror("pipe");
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
 
 #endif
 
-    printf("average latency: %li ns\n", delta / (count * 2));
+    printf("average latency: %lli ns\n", delta / (count * 2));
   }
 
   return 0;

--- a/src/pipe_thr.c
+++ b/src/pipe_thr.c
@@ -123,8 +123,8 @@ int main(int argc, char *argv[]) {
 
 #endif
 
-    printf("average throughput: %li msg/s\n", (count * 1000000) / delta);
-    printf("average throughput: %li Mb/s\n",
+    printf("average throughput: %lli msg/s\n", (count * 1000000) / delta);
+    printf("average throughput: %lli Mb/s\n",
            (((count * 1000000) / delta) * size * 8) / 1000000);
   }
 

--- a/src/tcp_lat.c
+++ b/src/tcp_lat.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
   }
 
   printf("message size: %i octets\n", size);
-  printf("roundtrip count: %li\n", count);
+  printf("roundtrip count: %lli\n", count);
 
   if (!fork()) { /* child */
 
@@ -198,7 +198,7 @@ int main(int argc, char *argv[]) {
 
 #endif
 
-    printf("average latency: %li ns\n", delta / (count * 2));
+    printf("average latency: %lli ns\n", delta / (count * 2));
   }
 
   return 0;

--- a/src/tcp_remote_lat.c
+++ b/src/tcp_remote_lat.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
   }
 
   printf("message size: %i octets\n", size);
-  printf("roundtrip count: %li\n", count);
+  printf("roundtrip count: %lli\n", count);
 
   memset(&hints, 0, sizeof hints);
   hints.ai_family = AF_UNSPEC; // use IPv4 or IPv6, whichever
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
   delta =
       (stop.tv_sec - start.tv_sec) * 1000000000 + (stop.tv_usec - start.tv_usec) * 1000;
 
-  printf("average latency: %li ns\n", delta / (count * 2));
+  printf("average latency: %lli ns\n", delta / (count * 2));
 
   return 0;
 }

--- a/src/tcp_thr.c
+++ b/src/tcp_thr.c
@@ -188,8 +188,8 @@ int main(int argc, char *argv[]) {
 
 #endif
 
-    printf("average throughput: %li msg/s\n", (count * 1000000) / delta);
-    printf("average throughput: %li Mb/s\n",
+    printf("average throughput: %lli msg/s\n", (count * 1000000) / delta);
+    printf("average throughput: %lli Mb/s\n",
            (((count * 1000000) / delta) * size * 8) / 1000000);
   }
 

--- a/src/unix_lat.c
+++ b/src/unix_lat.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
   }
 
   printf("message size: %i octets\n", size);
-  printf("roundtrip count: %li\n", count);
+  printf("roundtrip count: %lli\n", count);
 
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1) {
     perror("socketpair");
@@ -131,7 +131,7 @@ int main(int argc, char *argv[]) {
 
 #endif
 
-    printf("average latency: %li ns\n", delta / (count * 2));
+    printf("average latency: %lli ns\n", delta / (count * 2));
   }
 
   return 0;

--- a/src/unix_thr.c
+++ b/src/unix_thr.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
   }
 
   printf("message size: %i octets\n", size);
-  printf("message count: %li\n", count);
+  printf("message count: %lli\n", count);
 
   if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == -1) {
     perror("socketpair");
@@ -122,8 +122,8 @@ int main(int argc, char *argv[]) {
 
 #endif
 
-    printf("average throughput: %li msg/s\n", (count * 1000000) / delta);
-    printf("average throughput: %li Mb/s\n",
+    printf("average throughput: %lli msg/s\n", (count * 1000000) / delta);
+    printf("average throughput: %lli Mb/s\n",
            (((count * 1000000) / delta) * size * 8) / 1000000);
   }
 


### PR DESCRIPTION
As compiler says:

> format specifies type 'long' but the argument has type 'int64_t' (aka 'long long')

Found using Clang's -Wformat